### PR TITLE
Add data persistence.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,12 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-parcelize'
+    id 'kotlin-kapt'
 }
 
 android {
-    compileSdk 30
+    compileSdk 31
 
     defaultConfig {
         applicationId "monster.minions.binocularss"
@@ -64,4 +66,17 @@ dependencies {
 
     // RSS parser library
     implementation 'com.prof18.rssparser:rssparser:3.1.5'
+
+    // GSON
+    implementation 'com.google.code.gson:gson:2.8.9'
+
+    // Room
+    def room_version = "2.3.0"
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+//    implementation "androidx.room:room-rxjava2:$room_version" // optional - RxJava2 support for Room
+//    implementation "androidx.room:room-rxjava3:$room_version" // optional - RxJava3 support for Room
+//    implementation "androidx.room:room-guava:$room_version" // optional - Guava support for Room, including Optional and ListenableFuture
+    testImplementation "androidx.room:room-testing:$room_version" // optional - Test helpers
+//    implementation "androidx.room:room-paging:2.4.0-beta01" // optional - Paging 3 Integration
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.BinoculaRSS">
+        android:theme="@style/Theme.BinoculaRSS"
+        android:usesCleartextTraffic="true" >
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/monster/minions/binocularss/AppDatabase.kt
+++ b/app/src/main/java/monster/minions/binocularss/AppDatabase.kt
@@ -1,0 +1,15 @@
+package monster.minions.binocularss
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * A class to call on the database
+ */
+@Database(entities = [Feed::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    /**
+     * A feed Data Access Object (DAO)
+     */
+    abstract fun feedDao(): FeedDao
+}

--- a/app/src/main/java/monster/minions/binocularss/Article.kt
+++ b/app/src/main/java/monster/minions/binocularss/Article.kt
@@ -1,28 +1,49 @@
 package monster.minions.binocularss
 
-import java.net.URL
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 /**
- * from https://validator.w3.org/feed/docs/rss2.html
+ * A dataclass object representing an Article that is part of an RSS Feed.
+ *
+ * Info on possible tags from https://validator.w3.org/feed/docs/rss2.html
+ *
+ * @param title The title of the item.
+ * @param author Email address of the author of the item.
+ * @param link The URL of the item.
+ * @param pubDate Indicates when the item was published.
+ * @param description The item synopsis.
+ * @param content The content of an item, also known as enclosure.
+ * @param image An href to a header image.
+ * @param audio An href to companion audio.
+ * @param video An href to companion video.
+ * @param guid A string that uniquely identifies the item.
+ * @param sourceName The source name (name of the feed it came from).
+ * @param sourceUrl The source URL (url of the feed it came from).
+ * @param categories A list of Source-defined categories.
  */
-
+@Parcelize
 data class Article(
-    var title: String = "", // The title of the item.
-    var author: String = "", // Email address of the author of the item.
-    var link: String = "", // The URL of the item.
-    var pubDate: String = "", // Indicates when the item was published.
-    var description: String = "", // The item synopsis.
-    var content: String = "", // The content of an item, also known as enclosure
-    var image: String = "", // An href to a header image
-    var audio: String = "", // An href to companion audio
-    var video: String = "", // An href to companion video
-    var sourceName: String = "", // The source name (name of the feed it came from)
-    var sourceUrl: String = "", // The source URL (url of the feed it came from)
-    var categories: MutableList<String> = mutableListOf<String>(), // A list of the appropriate categories (predefiend)
-    var guid: String = "", // A string that uniquely identifies the item.
-    var source: String = "", // The RSS channel that the item came from.
-) {
-
+    var title: String? = "",
+    var author: String? = "",
+    var link: String? = "",
+    var pubDate: String? = "",
+    var description: String? = "",
+    var content: String? = "",
+    var image: String? = "",
+    var audio: String? = "",
+    var video: String? = "",
+    var guid: String? = "",
+    var sourceName: String? = "",
+    var sourceUrl: String? = "",
+    var categories: MutableList<String>? = mutableListOf()
+) : Parcelable {
+    /**
+     * Check if an article is equal to another by checking the
+     * link, which usually does not change
+     *
+     * @param other Another object. If it is not an article, return false immediately.
+     */
     override fun equals(other: Any?): Boolean {
         return when (other) {
             is Article -> {
@@ -32,5 +53,25 @@ data class Article(
                 false
             }
         }
+    }
+
+    /**
+     * Calculate a hash code for the Article.
+     */
+    override fun hashCode(): Int {
+        var result = title?.hashCode() ?: 0
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + (link?.hashCode() ?: 0)
+        result = 31 * result + (pubDate?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (content?.hashCode() ?: 0)
+        result = 31 * result + (image?.hashCode() ?: 0)
+        result = 31 * result + (audio?.hashCode() ?: 0)
+        result = 31 * result + (video?.hashCode() ?: 0)
+        result = 31 * result + (guid?.hashCode() ?: 0)
+        result = 31 * result + (sourceName?.hashCode() ?: 0)
+        result = 31 * result + (sourceUrl?.hashCode() ?: 0)
+        result = 31 * result + (categories?.hashCode() ?: 0)
+        return result
     }
 }

--- a/app/src/main/java/monster/minions/binocularss/ArticleListConverter.kt
+++ b/app/src/main/java/monster/minions/binocularss/ArticleListConverter.kt
@@ -1,0 +1,36 @@
+package monster.minions.binocularss
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * A object to convert between a list of articles and JSON for Room database storage requirements.
+ */
+object ArticleListConverter {
+    private val gson: Gson = Gson()
+
+    /**
+     * Convert a list of articles to a JSON.
+     *
+     * @param articleList A list of articles.
+     * @return A string formatted as a JSON representing a list of Article objects
+     */
+    @TypeConverter
+    fun toString(articleList: List<Article>?): String? {
+        return gson.toJson(articleList)
+    }
+
+    /**
+     * Convert a JSON string to a list of articles.
+     *
+     * @param str A string formatted as a JSON representing a list of Article objects
+     * @return A list of articles.
+     */
+    @TypeConverter
+    fun toArticleList(str: String?): MutableList<Article> {
+        val listType = object: TypeToken<List<Article>>() {}.type
+        val articles = gson.fromJson<List<Article>>(str, listType)
+        return articles.toMutableList()
+    }
+}

--- a/app/src/main/java/monster/minions/binocularss/Feed.kt
+++ b/app/src/main/java/monster/minions/binocularss/Feed.kt
@@ -1,18 +1,38 @@
 package monster.minions.binocularss
 
-import com.prof.rssparser.Image
+import android.os.Parcelable
+import androidx.annotation.NonNull
+import androidx.room.*
+import kotlinx.parcelize.Parcelize
 
 /**
- * from https://validator.w3.org/feed/docs/rss2.html
+ * A dataclass object representing an RSS Feed.
+ *
+ * Info on possible tags from https://validator.w3.org/feed/docs/rss2.html
+ *
+ * @param title The name of the channel. It's how people refer to your service. If you have an HTML website that contains the same information as your RSS file, the title of your channel should be the same as the title of your website.
+ * @param link The URL to the HTML website corresponding to the channel.
+ * @param description Phrase or sentence describing the channel.
+ * @param lastBuildDate The last time the content of the channel changed.
+ * @param image Specifies the url for a GIF, JPEG or PNG image that can be displayed with the channel.
+ * @param updatePeriod Specifies the amount of time between updates for RSS aggregators.
+ * @param articles A list of articles that the feed contains.
+ * @param tags The user assigned tags on a feed.
+ * @param priority The computed priority score of a feed.
  */
+@Parcelize
+@Entity(tableName = "feeds")
+@TypeConverters(ArticleListConverter::class, TagsListConverter::class)
 data class Feed(
-    var title: String = "", // The name of the channel. It's how people refer to your service. If you have an HTML website that contains the same information as your RSS file, the title of your channel should be the same as the title of your website.
-    var link: String = "", // The URL to the HTML website corresponding to the channel.
-    var description: String = "", // Phrase or sentence describing the channel.
-    var lastBuildDate: String = "", // The last time the content of the channel changed.
-    var image: Image? = null, // Specifies a GIF, JPEG or PNG image that can be displayed with the channel.
-    var updatePeriod: String = "", // Specifies the amount of time between updates for RSS aggregators.
-    var articles: MutableList<Article> = mutableListOf<Article>(), // A list of articles that the feed contains.
-    var tags: List<String> = mutableListOf<String>(), // The user assigned tags on a feed
-    var priority: Int = 0 // The computed priority score of a feed.
-)
+    var title: String? = "",
+    @NonNull
+    @PrimaryKey
+    var link: String = "",
+    var description: String? = "",
+    var lastBuildDate: String? = "",
+    var image: String = "",
+    var updatePeriod: String? = "",
+    var articles: MutableList<Article> = mutableListOf(),
+    var tags: MutableList<String> = mutableListOf(),
+    var priority: Int = 0,
+) : Parcelable

--- a/app/src/main/java/monster/minions/binocularss/FeedDao.kt
+++ b/app/src/main/java/monster/minions/binocularss/FeedDao.kt
@@ -1,0 +1,45 @@
+package monster.minions.binocularss
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+/**
+ * Interface to translate from Kotlin function calls to SQLite queries
+ */
+@Dao
+interface FeedDao {
+    /**
+     * Insert all feeds passed to it into the database.
+     *
+     * @param feeds An unspecified number of feeds.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAll(vararg feeds: Feed)
+
+    /**
+     * Insert a single feed passed to it into the database.
+     *
+     * @param feed A feed object.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(feed: Feed)
+
+    /**
+     * Delete a Feed from the database
+     *
+     * @param feed A feed object.
+     */
+    @Delete
+    fun delete(feed: Feed)
+
+    /**
+     * Get a mutable list of all the feeds from the database.
+     *
+     * @return A mutable list of Feed objects.
+     */
+    @Query("SELECT * FROM feeds")
+    fun getAll(): MutableList<Feed>
+}

--- a/app/src/main/java/monster/minions/binocularss/FeedGroup.kt
+++ b/app/src/main/java/monster/minions/binocularss/FeedGroup.kt
@@ -1,5 +1,12 @@
 package monster.minions.binocularss
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * A dataclass object representing a group of RSS Feeds.
+ */
+@Parcelize
 data class FeedGroup(
-    var feeds: MutableList<Feed> = mutableListOf<Feed>(),
-)
+    var feeds: MutableList<Feed> = mutableListOf()
+): Parcelable

--- a/app/src/main/java/monster/minions/binocularss/MainActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/MainActivity.kt
@@ -1,91 +1,245 @@
 package monster.minions.binocularss
 
 import android.content.Context
-import android.os.AsyncTask.execute
 import android.os.Bundle
-import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.*
-import com.prof.rssparser.Channel
+import androidx.room.Room
+import androidx.room.RoomDatabase
 import com.prof.rssparser.Parser
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import monster.minions.binocularss.ui.theme.BinoculaRSSTheme
-import java.nio.charset.Charset
-import kotlin.coroutines.CoroutineContext
 
 class MainActivity : ComponentActivity() {
 
+    // Variables that can be accessed from other classes by calling `MainActivity.<variable>`.
     companion object {
+        // Global FeedGroup object
         var feedGroup: FeedGroup = FeedGroup()
+        // Parser variable using lateinit because we want to get the context
+        private lateinit var parser: Parser
+        // Setup parser
+        private fun setParser(context: Context) {
+            parser = Parser.Builder()
+                .context(context)
+                // .charset(Charset.forName("ISO-8859-7")) // Default is UTF-8
+                .cacheExpirationMillis(24L * 60L * 60L * 100L) // Set the cache to expire in one day
+                .build()
+
+
+        }
+        // Setup Room database
+        private lateinit var db: RoomDatabase
+        private lateinit var feedDao: FeedDao
+        private fun setDb(context: Context) {
+            db = Room.databaseBuilder(
+                context,
+                AppDatabase::class.java, "feed-db"
+            ).allowMainThreadQueries().build()
+            feedDao = (db as AppDatabase).feedDao()
+        }
+
+        // Key for accessing feed group in onSaveInstanceState
+        // const val FEED_GROUP_KEY = "feedGroup"
     }
 
+    // Local variables
+    private val feedGroupText = MutableStateFlow("Empty\n")
+
+    /**
+     * The function that is run when the activity is created. This is on app launch in this case.
+     * It is also called when the activity is destroyed then recreated. It initializes the main
+     * functionality of the application (UI, companion variables, etc.)
+     *
+     * @param savedInstanceState A bundle of parcelable information that was previously saved.
+     */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // TODO this code goes with onSaveInstanceState and onRestoreInstanceState
+        // if (savedInstanceState != null) {
+        // feedGroup = savedInstanceState.getParcelable<FeedGroup>("feedGroup")!!
+        //    Toast.makeText(this@MainActivity, feedGroup.feeds[0].title, Toast.LENGTH_SHORT).show()
+        // }
+
         setContent {
             BinoculaRSSTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(color = MaterialTheme.colors.background) {
-                    Greeting("Minions")
+                    Column(modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally) {
+                        FeedTitles()
+                        UpdateFeedButton()
+                    }
                 }
             }
         }
 
-        // Add some feeds to the feedGroup
-        feedGroup.feeds.add(Feed(link = "https://rss.cbc.ca/lineup/topstories.xml"))
-        feedGroup.feeds.add(Feed(link = "https://androidauthority.com/feed"))
-        feedGroup.feeds.add(Feed(link = "https://www.nasa.gov/rss/dyn/Gravity-Assist.rss"))
-        feedGroup.feeds.add(Feed(link = "https://www.nasa.gov/rss/dyn/Houston-We-Have-a-Podcast.rss"))
 
-        // Setup parser
-        val parser = Parser.Builder()
-            .context(this)
-            // .charset(Charset.forName("ISO-8859-7")) // Default is UTF-8
-            .cacheExpirationMillis(24L * 60L * 60L * 100L) // Set the cache to expire in one day
-            .build()
-
-        // Update Rss
-        updateRss(feedGroup, parser, this@MainActivity)
+        // Set feed-db in companion object
+        setDb(applicationContext)
+        // Set parser in companion object
+        setParser(this@MainActivity)
     }
 
     /**
      * Call the required functions to update the Rss feed.
      *
-     * @param feedGroup A group of feeds to be updated.
      * @param parser A parser with preconfigured settings.
-     * @param context The application context (current view).
      */
     @DelicateCoroutinesApi
-    private fun updateRss(feedGroup: FeedGroup, parser: Parser, context: Context) {
-        val viewModel = PullFeed(context)
+    private fun updateRss(parser: Parser) {
+        val viewModel = PullFeed()
 
         GlobalScope.launch(Dispatchers.Main) {
-            MainActivity.feedGroup = viewModel.pullRss(MainActivity.feedGroup, parser)
-
+            feedGroup = viewModel.pullRss(feedGroup, parser)
             // Debug toast to confirm that the data has come back to the MainActivity variable.
-            for (feed in MainActivity.feedGroup.feeds) {
-                Toast.makeText(context, "Pulled: ${feed.title}", Toast.LENGTH_SHORT).show()
+            // for (feed in MainActivity.feedGroup.feeds) {
+            //     Toast.makeText(context, "Pulled: ${feed.title}", Toast.LENGTH_SHORT).show()
+            // }
+            var text = ""
+            for (feed in feedGroup.feeds) {
+                text += feed.title
+                text += "\n"
+            }
+            feedGroupText.value = text
+        }
+    }
+
+    // /**
+    //  * Saves instance state when activity is destroyed
+    //  *
+    //  * TODO: We do not need onSaveInstanceState (goes with onRestoreInstanceState) for the current
+    //  *  use case. The room database handles
+    //  *  it all. I am leaving it here so that whoever uses it has a base for the code
+    //  *
+    //  * @param outState A bundle of instance state information stored using key-value pairs
+    //  */
+    // override fun onSaveInstanceState(outState: Bundle) {
+    //     Log.d("MainActivity", "onSaveInstanceState called")
+    //     super.onSaveInstanceState(outState)
+    //     outState.putParcelable(FEED_GROUP_KEY, feedGroup)
+    // }
+
+    // /**
+    //  * Restores instance state when activity is recreated
+    //  *
+    //  * TODO: We do not need onRestoreInstanceState (goes with onSaveInstanceState) for the current
+    //  *  use case. The room database handles it all. I am leaving it here so that whoever uses it
+    //  *  has a base for the code
+    //  *
+    //  * @param savedInstanceState A bundle of instance state information stored using key-value pairs
+    //  */
+    // override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+    //     Log.d("MainActivity", "onRestoreInstanceState called")
+    //     super.onRestoreInstanceState(savedInstanceState)
+    //     feedGroup = savedInstanceState.getParcelable<FeedGroup>(FEED_GROUP_KEY)!!
+
+    //     var text = ""
+    //     for (feed in feedGroup.feeds) {
+    //         text += feed.title
+    //         text += "\n"
+    //     }
+    //     feedGroupText.value = text
+    // }
+
+    /**
+     * Save the list of user feeds to the Room database (feed-db) for data persistence.
+     *
+     * The database files can be found in `Android/data/data/monster.minions.binocularss.databases`.
+     *
+     * This function is called before `onStop` and `onDestroy` or any time a "pause" happens. This
+     * includes when an app is exited but not closed.
+     */
+    override fun onPause() {
+        super.onPause()
+        Log.d("MainActivity", "onPause called")
+        feedDao.insertAll(*(feedGroup.feeds.toTypedArray()))
+    }
+
+    /**
+     * Gets the list of user feeds from the Room database (feed-db).
+     *
+     * The database files can be found in `Android/data/data/monster.minions.binocularss.databases`.
+     *
+     * This function is called after `onCreate` or any time a "resume" happens. This includes
+     * the app being opened after the app is exited but not closed.
+     */
+    override fun onResume() {
+        super.onResume()
+        Log.d("MainActivity", "onResume called")
+
+        val feeds: MutableList<Feed> = feedDao.getAll()
+
+        feedGroup.feeds = feeds
+
+        ///////////////////////////////////////////////////////////////////////////////////////////
+        // NOT PERMANENT: If the user does not have any feeds added, add some.
+        if (feedGroup.feeds.isNullOrEmpty()) {
+            // Add some feeds to the feedGroup
+            feedGroup.feeds.add(Feed(link = "https://rss.cbc.ca/lineup/topstories.xml"))
+            feedGroup.feeds.add(Feed(link = "https://androidauthority.com/feed"))
+            // TODO This feed is malformed according to the exception that the xml parser throws.
+            //  We can use this to develop a bad formatting indication to the user
+            //  feedGroup.feeds.add(Feed(link = "https://www.nasa.gov/rss/dyn/Gravity-Assist.rss"))
+            feedGroup.feeds.add(Feed(link = "https://www.nasa.gov/rss/dyn/Houston-We-Have-a-Podcast.rss"))
+
+            // Tell the user that this change happened
+            Toast.makeText(this@MainActivity, "Added Sample Feeds to feedGroup", Toast.LENGTH_SHORT)
+                .show()
+        }
+        ///////////////////////////////////////////////////////////////////////////////////////////
+
+        var text = ""
+        for (feed in feedGroup.feeds) {
+            text += feed.title
+            text += "\n"
+        }
+        feedGroupText.value = text
+    }
+
+    @Composable
+    fun FeedTitles() {
+        val text by feedGroupText.collectAsState()
+        Text(text = text)
+    }
+
+    @Composable
+    fun UpdateFeedButton() {
+        Button(
+            onClick = { updateRss(parser) }
+        ) {
+            Text("Update RSS Feeds")
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    fun DefaultPreview() {
+        BinoculaRSSTheme {
+            Column {
+                FeedTitles()
+                UpdateFeedButton()
             }
         }
     }
 }
 
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    BinoculaRSSTheme {
-        Greeting("Android")
-    }
-}

--- a/app/src/main/java/monster/minions/binocularss/TagsListConverter.kt
+++ b/app/src/main/java/monster/minions/binocularss/TagsListConverter.kt
@@ -1,0 +1,49 @@
+package monster.minions.binocularss
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+
+/**
+ * A object to convert between a list of tags and CSV for Room database storage requirements.
+ */
+object TagsListConverter {
+    private val gson = Gson()
+
+    /**
+     * Convert a list of tags to a CSV.
+     * TODO ensure that tags (user entered) cannot include a comma or other special characters.
+     *
+     * @param tags A list of tags.
+     * @return A string that contains comma separated values.
+     */
+    @TypeConverter
+    fun toString(tags: List<String>?): String? {
+        if (tags == null) return null
+
+        val stringList = mutableListOf<String>()
+
+        for (tag in tags) {
+            stringList.add(tag)
+        }
+
+        return stringList.joinToString(",")
+        // Gson implementation -- currently crashes (in the other method)
+        // return gson.toJson(tags)
+    }
+
+    /**
+     * Decode a CSV to a list of tags.
+     *
+     * @param str A string that contains comma separated values.
+     * @return A list of tags.
+     */
+    @TypeConverter
+    fun toTagList(str: String?): MutableList<String>? {
+        if (str == null) return null
+        return str.split(",") as MutableList<String>
+        // Gson implementation -- currently crashes
+        // val listType = object: TypeToken<List<String>>() {}.type
+        // val tags = gson.fromJson<List<String>>(str, listType)
+        // return tags.toMutableList()
+    }
+}


### PR DESCRIPTION
Using a Room database (layer of abstraction for SQLite), this branch implements persistence to allow a user's feeds to be saved on app close and reloaded on app open. This means that the user saves bandwidth by not having to retrieve feeds every time the lifecycle renews. It also means that the user can still read old articles they have retrieved that have since been removed from the feeds they subscribe to. The system could even be extended to allow the user to read entire feeds that have been removed which the user has retrieved (in their last published state, of course). Here is a demonstration of the persistence in action:

https://user-images.githubusercontent.com/34548959/139519294-020ace1f-a4d6-45d8-82f3-06b552b21003.mp4