### PR TITLE
Remove direct access to MainActivity.* variables and access DB instead

### DIFF
--- a/app/src/main/java/monster/minions/binocularss/activities/BookmarksActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/BookmarksActivity.kt
@@ -2,20 +2,18 @@ package monster.minions.binocularss.activities
 
 import android.content.Intent
 import android.net.Uri
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.*
-
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -24,12 +22,12 @@ import androidx.room.RoomDatabase
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import monster.minions.binocularss.R
+import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
 import monster.minions.binocularss.dataclasses.Article
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.room.AppDatabase
 import monster.minions.binocularss.room.FeedDao
-import monster.minions.binocularss.ui.theme.BinoculaRSSTheme
-import monster.minions.binocularss.ui.theme.BookmarkFlag
+import monster.minions.binocularss.ui.BookmarkFlag
 
 class BookmarksActivity : AppCompatActivity() {
 
@@ -41,9 +39,6 @@ class BookmarksActivity : AppCompatActivity() {
 
     private var feedGroup = FeedGroup()
 
-
-
-    
     @ExperimentalMaterialApi
     @ExperimentalCoilApi
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,14 +52,12 @@ class BookmarksActivity : AppCompatActivity() {
             BinoculaRSSTheme() {
                 Surface(
                     color = MaterialTheme.colors.background
-                ){
+                ) {
                     Bookmarks(getAllBookmarks())
                 }
 
             }
         }
-
-
     }
 
     /**
@@ -77,16 +70,15 @@ class BookmarksActivity : AppCompatActivity() {
     @ExperimentalMaterialApi
     @ExperimentalCoilApi
     @Composable
-    fun Bookmarks(bookmarked_articles: MutableList<Article>){
+    fun Bookmarks(bookmarked_articles: MutableList<Article>) {
 
         LazyColumn(modifier = Modifier.padding(vertical = 4.dp)) {
-           items(items = bookmarked_articles){ article ->
-               Bookmark(article = article)
-           }
+            items(items = bookmarked_articles) { article ->
+                Bookmark(article = article)
+            }
 
         }
     }
-
 
     /**
      * Save the list of user feeds to the Room database (feed-db) for data persistence.
@@ -96,14 +88,14 @@ class BookmarksActivity : AppCompatActivity() {
      * This function is called before `onStop` and `onDestroy` or any time a "stop" happens. This
      * includes when an app is exited but not closed.
      */
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         Log.d("BookmarksActivity", "onStop called")
         feedDao.insertAll(*(feedGroup.feeds.toTypedArray()))
     }
 
     /**
-     * Gets the list of user feeds from the Room database (feed-db).
+     * Get the list of user feeds from the Room database (feed-db).
      *
      * The database files can be found in `Android/data/data/monster.minions.binocularss.databases`.
      *
@@ -113,10 +105,7 @@ class BookmarksActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         Log.d("BookmarksActivity", "onResume called")
-
-
         feedGroup.feeds = feedDao.getAll()
-
     }
 
     /**
@@ -127,8 +116,7 @@ class BookmarksActivity : AppCompatActivity() {
     @ExperimentalMaterialApi
     @ExperimentalCoilApi
     @Composable
-    fun Bookmark(article: Article){
-
+    fun Bookmark(article: Article) {
         Card(
             modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
             onClick = {
@@ -140,13 +128,8 @@ class BookmarksActivity : AppCompatActivity() {
             CardContent(
                 article
             )
-
         }
-
     }
-
-
-
 
     /**
      * Composable for actual content of the bookmarked
@@ -156,8 +139,7 @@ class BookmarksActivity : AppCompatActivity() {
      */
     @ExperimentalCoilApi
     @Composable
-    fun CardContent(article: Article){
-
+    fun CardContent(article: Article) {
         Column(
             modifier = Modifier
                 .padding(12.dp)
@@ -167,7 +149,6 @@ class BookmarksActivity : AppCompatActivity() {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-
                 Text(
                     text = article.title.toString(),
                     textAlign = TextAlign.Left,
@@ -192,32 +173,23 @@ class BookmarksActivity : AppCompatActivity() {
             )
             BookmarkFlag(article)
         }
-
     }
-
-
-
-
 
     /**
      * Returns a list of bookmarked articles within the feedgroup
      * stored within MainActivity
      */
     private fun getAllBookmarks(): MutableList<Article> {
-
-        val feeds = feedGroup.feeds
-        var articles: List<Article>
         val bookmarkedArticles: MutableList<Article> = mutableListOf()
 
-        for (feed in feeds){
-            articles = feed.articles
-            for (article in articles){
-                if (article.bookmarked){
+        for (feed in feedGroup.feeds) {
+            for (article in feed.articles) {
+                if (article.bookmarked) {
                     bookmarkedArticles.add(article)
                 }
             }
-
         }
+
         return bookmarkedArticles
     }
 }

--- a/app/src/main/java/monster/minions/binocularss/ui/Icons.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Icons.kt
@@ -1,4 +1,4 @@
-package monster.minions.binocularss.ui.theme
+package monster.minions.binocularss.ui
 
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.BookmarkBorder as EmptyBookmarkIco
  */
 @Composable
 fun BookmarkFlag(article: Article) {
-
     var isBookmarked by remember { mutableStateOf(article.bookmarked) }
 
     IconButton(
@@ -30,11 +29,10 @@ fun BookmarkFlag(article: Article) {
             isBookmarked = !isBookmarked
             article.bookmarked = !article.bookmarked
         }
-        ) {
+    ) {
         Icon(
             imageVector = if (isBookmarked) Icons.Filled.FilledBookmarkIcon else Icons.Filled.EmptyBookmarkIcon,
             contentDescription = null
         )
     }
-
 }

--- a/phase1/design-document.md
+++ b/phase1/design-document.md
@@ -19,6 +19,7 @@ Our code fell into three camps. The first was good, "clean", code. This did not 
 <!-- is this in solid design principles or clean architecture or code smells? -->
 One such violation of clean architecture that we knew how to fix was duplication of code within our project. An example of this was our `updateRss()` function. This funciton called a series of other functions that needed to be called in a specific order with specific arguments, and in many different places. Hence, we though it a good idea to pull that code into a function, but even though we were trying to reduce duplication, there were still multiple `updateRss()` functions accross multiple classes where the RSS feeds needed to be updated from. There were two solutions to this. The first, the one that we did not do, we could have only called this function from the main task and simply returned a signal from other tasks telling this function to be called. While this would have arugably been more "clean," it is not as efficient and for an integral part of our program that is run many, many times, efficiency is of the utmost importance. The second, the way that we chose to do it, is to extract this function into another class and simply call it through an instance of that class whenever necessary. This eliminates the need for code duplication and allows all the classes to communicate with one common class that will handle all the data transmission.
 
+Another violation of clean architecture that we found within our code was accessing variables from one class in others. We initially had a global `feedGroup` variable (commit: [Merge pull request #7 from tminions/bookmarking](https://github.com/tminions/binocularss/commit/d83a9d3ee2c00b7249960b67bbaeedc00978c381)). We would access and update this in other classes like `AddFeedActivity` in order to change the state of the feeds in the application. We realized that this was bad practice so we tasked each activity with communicating with the database layer to retrieve the feeds on startup and write the feeds on change/exit. This meant that we were no longer "reaching" accross class borders to access variables that should be private. There is one exception to this, however, that we were not able to do the same with. There is a variable `feedGroupText` that represents the text of a UI element that we need to update upon completion of an asynchronous funciton. Since this asynchronous function is in another class (`PullFeed`), we need to allow that funciton access to this variable. We could not work out a way of going around this as attempting to update this text after the asynchronous function completes but on the main thread leads to timing complications as the asynchronous function can take an arbitrary amount of time to complete.
 
 ## Solid Design Principles
 
@@ -44,6 +45,14 @@ parser = Parser.Builder()
     .build()
 ```
 
+```kotlin
+db = Room
+    .databaseBuilder(this, AppDatabase::class.java, "feed-db")
+    .allowMainThreadQueries()
+    .build()
+
+```
+
 ## Progress report
 
 ### Open Questions
@@ -65,7 +74,9 @@ parser = Parser.Builder()
 
 - RSS parser
 - Data persistence 
-- Add, remove and organize feeds
+- Add feeds
+- Fix direct access to `MainActivity.feedGroup`
+- Settings page
 
 #### Ismail Ahmed
 


### PR DESCRIPTION
Previously, we were accessing MainActivity.feedGroup and other companion object variables. This is bad practice for clean code so instead, we should have each activity communicate with the database layer to retrieve the feeds on startup and write changes on exit. I also updated the Design Document with a section reflecting these changes.