### PR TITLE
Add dynamic open-source license information

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,18 +40,14 @@ android {
     buildFeatures {
         compose true
     }
-    // composeOptions {
-    //     kotlinCompilerExtensionVersion compose_version
-    //     kotlinCompilerVersion '1.5.31'
-    // }
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerVersion '1.5.31'
+    }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.21'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
+    // List open source licenses
+    id "com.mikepenz.aboutlibraries.plugin" version "10.0.0-b02"
 }
 
 android {
@@ -38,14 +40,18 @@ android {
     buildFeatures {
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.31'
-    }
+    // composeOptions {
+    //     kotlinCompilerExtensionVersion compose_version
+    //     kotlinCompilerVersion '1.5.31'
+    // }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerVersion '1.5.21'
     }
 }
 
@@ -96,4 +102,9 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     testImplementation "androidx.room:room-testing:$room_version" // optional - Test helpers
+
+    // AboutLibraries
+    def latestAboutLibsRelease = "10.0.0-b02"
+    implementation "com.mikepenz:aboutlibraries-core:$latestAboutLibsRelease"
+    implementation "com.mikepenz:aboutlibraries-compose:$latestAboutLibsRelease"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
         android:theme="@style/Theme.BinoculaRSS"
         android:usesCleartextTraffic="true">
         <activity
+            android:name=".activities.LicensesActivity"
+            android:exported="false"
+            android:label="@string/title_activity_libraries"
+            android:theme="@style/Theme.BinoculaRSS.NoActionBar" />
+        <activity
             android:name=".activities.SettingsActivity"
             android:exported="false"
             android:label="@string/title_activity_settings"

--- a/app/src/main/java/monster/minions/binocularss/activities/LicensesActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/LicensesActivity.kt
@@ -1,0 +1,103 @@
+package monster.minions.binocularss.activities
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
+import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+
+class LicensesActivity : ComponentActivity() {
+
+    // SharedPreferences variables.
+    private lateinit var sharedPref: SharedPreferences
+    private lateinit var sharedPrefEditor: SharedPreferences.Editor
+    private lateinit var theme: String
+    private lateinit var themeState: MutableState<String>
+    private var cacheExpiration = 0L
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            themeState = remember { mutableStateOf(theme) }
+            BinoculaRSSTheme(theme = themeState.value) {
+                UI()
+            }
+        }
+
+        // Initialize lateinit variables.
+        sharedPref = this.getSharedPreferences(
+            SettingsActivity.PreferenceKeys.SETTINGS,
+            Context.MODE_PRIVATE
+        )
+        sharedPrefEditor = sharedPref.edit()
+        theme =
+            sharedPref.getString(SettingsActivity.PreferenceKeys.THEME, "System Default").toString()
+        cacheExpiration = sharedPref.getLong(SettingsActivity.PreferenceKeys.CACHE_EXPIRATION, 0L)
+    }
+
+    /**
+     * Top navigation bar
+     */
+    @Composable
+    fun TopBar() {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Back button icon that goes back one activity.
+            IconButton(onClick = { finish() }) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = "Back Arrow"
+                )
+            }
+            Spacer(Modifier.padding(4.dp))
+            // Title of current page.
+            Text("Open-Source Licenses", style = MaterialTheme.typography.h5)
+        }
+    }
+
+    @Composable
+    fun UI() {
+        // Set status bar and nav bar colours.
+        val systemUiController = rememberSystemUiController()
+        val useDarkIcons = MaterialTheme.colors.isLight
+        val color = MaterialTheme.colors.background
+        SideEffect {
+            systemUiController.setSystemBarsColor(
+                color = color,
+                darkIcons = useDarkIcons
+            )
+        }
+
+        Surface(color = MaterialTheme.colors.background) {
+            Scaffold(topBar = { TopBar() }) {
+                // Call the library to generate the list of libraries
+                LibrariesContainer(
+                    Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    fun Preview() {
+        UI()
+    }
+}

--- a/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -70,9 +69,7 @@ class SettingsActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             themeState = remember { mutableStateOf(theme) }
-            BinoculaRSSTheme(
-                theme = themeState.value
-            ) {
+            BinoculaRSSTheme(theme = themeState.value) {
                 UI()
             }
         }
@@ -131,9 +128,7 @@ class SettingsActivity : ComponentActivity() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             // Back button icon that goes back one activity.
-            IconButton(onClick = {
-                finish()
-            }) {
+            IconButton(onClick = { finish() }) {
                 Icon(
                     imageVector = Icons.Filled.ArrowBack,
                     contentDescription = "Back Arrow"
@@ -320,28 +315,12 @@ class SettingsActivity : ComponentActivity() {
                             openLink(it)
                         }
                         // Popup information on all the open source libraries used.
-                        InformationPopupItem(title = "Open Source Libraries") {
-                            Text(
-                                "RSS-Parser",
-                                Modifier
-                                    .padding(top = 4.dp)
-                                    .clickable { openLink("https://github.com/prof18/RSS-Parser") })
-                            Text(
-                                "Coil",
-                                Modifier
-                                    .padding(top = 4.dp)
-                                    .clickable { openLink("https://github.com/coil-kt/coil") })
-                            Text(
-                                "Room",
-                                Modifier
-                                    .padding(top = 4.dp)
-                                    .clickable { openLink("https://developer.android.com/training/data-storage/room") })
-                            Text(
-                                "Material.io Theming Information",
-                                Modifier
-                                    .padding(top = 4.dp)
-                                    .clickable { openLink("https://material.io/design/color/the-color-system.html#color-theme-creation") })
-                            // TODO finish adding libraries then size the popup accordinly
+                        ActionItem(title = "Open Source Libraries") {
+                            val intent = Intent(
+                                this@SettingsActivity,
+                                LicensesActivity::class.java
+                            ).apply {}
+                            startActivity(intent)
                         }
                     }
                 }

--- a/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
@@ -314,8 +314,8 @@ class SettingsActivity : ComponentActivity() {
                         ) {
                             openLink(it)
                         }
-                        // Popup information on all the open source libraries used.
-                        ActionItem(title = "Open Source Libraries") {
+                        // Item that displays information on all the open source libraries used.
+                        ActionItem(title = "Open-Source Licenses") {
                             val intent = Intent(
                                 this@SettingsActivity,
                                 LicensesActivity::class.java

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">BinoculaRSS</string>
     <string name="title_activity_add_feed">AddFeedActivity</string>
     <string name="title_activity_settings">SettingsActivity</string>
+    <string name="title_activity_libraries">LibrariesActivity</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.3"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31'
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This branch adds dynamic open-source license information. It is accessible via `Settings > Open-Source Licenses`. The list is generated upon compile time by a grade plugin as a JSON file, which is then used to render the list in the application.

https://user-images.githubusercontent.com/34548959/143969911-3a10a991-6ea2-4cf5-a3cc-0bfbbba35c5c.mp4