### PR TITLE
Standardize padding, shape, and typography values

### DIFF
--- a/app/src/main/java/monster/minions/binocularss/activities/AddFeedActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/AddFeedActivity.kt
@@ -30,6 +30,8 @@ import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.operations.*
 import monster.minions.binocularss.room.AppDatabase
 import monster.minions.binocularss.room.FeedDao
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
 
 // TODO check that this is an RSS feed (probably in pull feed or something of the sort and send a
 //  toast to the user if it is not. Try and check this when initially adding maybe? Basically deeper
@@ -231,10 +233,8 @@ class AddFeedActivity : ComponentActivity() {
         }
 
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-            val padding = 16.dp
-
             Column(
-                modifier = Modifier.padding(padding),
+                modifier = Modifier.padding(paddingLarge),
                 horizontalAlignment = Alignment.Start
             ) {
                 Row(
@@ -248,7 +248,7 @@ class AddFeedActivity : ComponentActivity() {
                             text = mutableStateOf(textState.text)
                         })
                     }
-                    Spacer(modifier = Modifier.padding(8.dp))
+                    Spacer(modifier = Modifier.padding(paddingMedium))
                     FloatingActionButton(
                         onClick = { submit() },
                         backgroundColor = MaterialTheme.colors.primary

--- a/app/src/main/java/monster/minions/binocularss/activities/AddFeedActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/AddFeedActivity.kt
@@ -19,19 +19,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.prof.rssparser.Parser
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
 import monster.minions.binocularss.dataclasses.Feed
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.operations.*
 import monster.minions.binocularss.room.AppDatabase
 import monster.minions.binocularss.room.FeedDao
-import monster.minions.binocularss.activities.ui.theme.paddingLarge
-import monster.minions.binocularss.activities.ui.theme.paddingMedium
 
 // TODO check that this is an RSS feed (probably in pull feed or something of the sort and send a
 //  toast to the user if it is not. Try and check this when initially adding maybe? Basically deeper

--- a/app/src/main/java/monster/minions/binocularss/activities/ArticleActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ArticleActivity.kt
@@ -35,8 +35,11 @@ import coil.compose.rememberImagePainter
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import monster.minions.binocularss.R
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingLargeMedium
+import monster.minions.binocularss.activities.ui.theme.paddingSmall
+import monster.minions.binocularss.activities.ui.theme.RoundedCorner
 import monster.minions.binocularss.dataclasses.Article
-import monster.minions.binocularss.dataclasses.Feed
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.room.AppDatabase
 import monster.minions.binocularss.room.FeedDao
@@ -193,7 +196,7 @@ class ArticleActivity : ComponentActivity() {
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp)
-                .padding(end = 16.dp),
+                .padding(end = paddingLarge),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -238,14 +241,14 @@ class ArticleActivity : ComponentActivity() {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 12.dp)
-                        .padding(bottom = 12.dp)
+                        .padding(horizontal = paddingLargeMedium)
+                        .padding(bottom = paddingLargeMedium)
                         .verticalScroll(rememberScrollState())
                 ) {
                     // Article heading
                     ArticleHeading()
 
-                    Box(modifier = Modifier.padding(bottom = 12.dp)) {
+                    Box(modifier = Modifier.padding(bottom = paddingLargeMedium)) {
                         // Article content
                         if (article.content.isNullOrEmpty() || article.content.toString() == "null") {
                             Text(
@@ -271,7 +274,7 @@ class ArticleActivity : ComponentActivity() {
                             },
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(end = 5.dp)
+                                .padding(end = paddingSmall)
                         ) {
                             Text(text = "Share")
                         }
@@ -283,7 +286,7 @@ class ArticleActivity : ComponentActivity() {
                             },
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(start = 5.dp)
+                                .padding(start = paddingSmall)
                         ) {
                             Text(text = "View article")
                         }
@@ -308,7 +311,7 @@ class ArticleActivity : ComponentActivity() {
                     "UNKNOWN ${typeOfInformation.uppercase()}" else text
             }",
             style = style,
-            modifier = if (atBottom) Modifier else Modifier.padding(bottom = 4.dp)
+            modifier = if (atBottom) Modifier else Modifier.padding(bottom = paddingSmall)
         )
     }
 
@@ -318,18 +321,18 @@ class ArticleActivity : ComponentActivity() {
     @ExperimentalCoilApi
     @Composable
     private fun ArticleHeading() {
-        Column(modifier = Modifier.padding(bottom = 12.dp)) {
+        Column(modifier = Modifier.padding(bottom = paddingLargeMedium)) {
             Text(
                 article.title.toString(),
                 style = MaterialTheme.typography.h5.copy(
                     fontWeight = FontWeight(700),
                     color = MaterialTheme.colors.onBackground
                 ),
-                modifier = Modifier.padding(vertical = 12.dp)
+                modifier = Modifier.padding(vertical = paddingLargeMedium)
             )
 
             Divider(thickness = 1.dp)
-            Spacer(modifier = Modifier.size(12.dp))
+            Spacer(modifier = Modifier.size(paddingLargeMedium))
 
             ArticleInformation(
                 text = article.author.toString().uppercase(),
@@ -345,9 +348,9 @@ class ArticleActivity : ComponentActivity() {
                 prefix = "",
             )
 
-            Spacer(modifier = Modifier.size(12.dp))
+            Spacer(modifier = Modifier.size(paddingLargeMedium))
             Divider(thickness = 1.dp)
-            Spacer(modifier = Modifier.size(12.dp))
+            Spacer(modifier = Modifier.size(paddingLargeMedium))
 
             Card(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/monster/minions/binocularss/activities/ArticleActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ArticleActivity.kt
@@ -13,7 +13,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -34,11 +33,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import monster.minions.binocularss.R
-import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
-import monster.minions.binocularss.activities.ui.theme.paddingLarge
-import monster.minions.binocularss.activities.ui.theme.paddingLargeMedium
-import monster.minions.binocularss.activities.ui.theme.paddingSmall
-import monster.minions.binocularss.activities.ui.theme.RoundedCorner
+import monster.minions.binocularss.activities.ui.theme.*
 import monster.minions.binocularss.dataclasses.Article
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.room.AppDatabase
@@ -354,8 +349,8 @@ class ArticleActivity : ComponentActivity() {
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(0.dp),
-                elevation = 5.dp
+                shape = RoundedCorner.small,
+                elevation = 4.dp
             ) {
                 Box(
                     modifier = Modifier.height(200.dp)

--- a/app/src/main/java/monster/minions/binocularss/activities/LicensesActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/LicensesActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingSmall
 
 class LicensesActivity : ComponentActivity() {
 
@@ -66,7 +67,7 @@ class LicensesActivity : ComponentActivity() {
                     contentDescription = "Back Arrow"
                 )
             }
-            Spacer(Modifier.padding(4.dp))
+            Spacer(Modifier.padding(paddingSmall))
             // Title of current page.
             Text("Open-Source Licenses", style = MaterialTheme.typography.h5)
         }

--- a/app/src/main/java/monster/minions/binocularss/activities/MainActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/MainActivity.kt
@@ -48,6 +48,9 @@ import com.prof.rssparser.Parser
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
+import monster.minions.binocularss.activities.ui.theme.paddingSmall
 import monster.minions.binocularss.dataclasses.Article
 import monster.minions.binocularss.dataclasses.Feed
 import monster.minions.binocularss.dataclasses.FeedGroup
@@ -272,7 +275,7 @@ class MainActivity : ComponentActivity() {
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(8.dp)
+                .padding(paddingMedium)
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onLongPress = {
@@ -286,13 +289,13 @@ class MainActivity : ComponentActivity() {
                             ContextCompat.startActivity(context, intent, null)
                         }
                     )
-                }, elevation = 4.dp
+                }, elevation = 8.dp
         ) {
             Column {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(paddingLarge),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     // Column for feed title.
@@ -356,7 +359,7 @@ class MainActivity : ComponentActivity() {
                     text = "No Feeds Found",
                     style = MaterialTheme.typography.h5
                 )
-                Spacer(Modifier.padding(16.dp))
+                Spacer(Modifier.padding(paddingLarge))
                 Button(
                     onClick = {
                         showAddFeed = false
@@ -402,7 +405,7 @@ class MainActivity : ComponentActivity() {
                     text = "No Articles Found",
                     style = MaterialTheme.typography.h5
                 )
-                Spacer(Modifier.padding(16.dp))
+                Spacer(Modifier.padding(paddingLarge))
                 Button(
                     onClick = {
                         val intent =
@@ -472,7 +475,7 @@ class MainActivity : ComponentActivity() {
                         text = "No Articles Found",
                         style = MaterialTheme.typography.h5
                     )
-                    Spacer(Modifier.padding(16.dp))
+                    Spacer(Modifier.padding(paddingLarge))
                     Button(
                         onClick = {
                             val intent =
@@ -497,14 +500,14 @@ class MainActivity : ComponentActivity() {
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.h5
                     )
-                    Spacer(Modifier.padding(4.dp))
+                    Spacer(Modifier.padding(paddingSmall))
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
                         text = "Read an article and it will show up here",
                         style = MaterialTheme.typography.body1
                     )
-                    Spacer(Modifier.padding(16.dp))
+                    Spacer(Modifier.padding(paddingLarge))
                     Button(onClick = {
                         // Update readArticleList when any nav item is clicked.
                         readArticleList.value =
@@ -568,7 +571,7 @@ class MainActivity : ComponentActivity() {
                         text = "No Articles Found",
                         style = MaterialTheme.typography.h5
                     )
-                    Spacer(Modifier.padding(16.dp))
+                    Spacer(Modifier.padding(paddingLarge))
                     Button(
                         onClick = {
                             val intent =
@@ -596,14 +599,14 @@ class MainActivity : ComponentActivity() {
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.h5
                     )
-                    Spacer(Modifier.padding(4.dp))
+                    Spacer(Modifier.padding(paddingSmall))
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,
                         text = "Bookmark an article and it will show up here",
                         style = MaterialTheme.typography.body1
                     )
-                    Spacer(Modifier.padding(16.dp))
+                    Spacer(Modifier.padding(paddingLarge))
                     Button(onClick = {
                         // Update bookmarkedArticleList when any nav item is clicked.
                         bookmarkedArticleList.value =
@@ -653,7 +656,7 @@ class MainActivity : ComponentActivity() {
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp)
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = paddingLarge),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/app/src/main/java/monster/minions/binocularss/activities/SearchActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SearchActivity.kt
@@ -15,11 +15,9 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import coil.annotation.ExperimentalCoilApi

--- a/app/src/main/java/monster/minions/binocularss/activities/SearchActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SearchActivity.kt
@@ -26,6 +26,7 @@ import coil.annotation.ExperimentalCoilApi
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.prof.rssparser.Parser
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
 import monster.minions.binocularss.dataclasses.Article
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.operations.*
@@ -248,7 +249,7 @@ class SearchActivity : ComponentActivity() {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(8.dp)
+                        .padding(paddingMedium)
                 ) {
                     SearchBar()
                 }

--- a/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
@@ -245,7 +245,7 @@ class SettingsActivity : ComponentActivity() {
                             }
                         )
 
-                        val disableClearDatabase by remember {
+                        var disableClearDatabase by remember {
                             mutableStateOf(feedGroup.feeds.isNullOrEmpty())
                         }
 
@@ -260,6 +260,7 @@ class SettingsActivity : ComponentActivity() {
 
                             // Set feedGroup.feeds to empty
                             feedGroup.feeds = mutableListOf()
+                            disableClearDatabase = true
 
                             // Update MainActivity UI
                             MainActivity.articleList.value = mutableListOf()

--- a/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/SettingsActivity.kt
@@ -27,6 +27,8 @@ import monster.minions.binocularss.activities.SettingsActivity.PreferenceKeys.CA
 import monster.minions.binocularss.activities.SettingsActivity.PreferenceKeys.SETTINGS
 import monster.minions.binocularss.activities.SettingsActivity.PreferenceKeys.THEME
 import monster.minions.binocularss.activities.ui.theme.BinoculaRSSTheme
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingSmall
 import monster.minions.binocularss.dataclasses.Feed
 import monster.minions.binocularss.dataclasses.FeedGroup
 import monster.minions.binocularss.room.AppDatabase
@@ -134,7 +136,7 @@ class SettingsActivity : ComponentActivity() {
                     contentDescription = "Back Arrow"
                 )
             }
-            Spacer(Modifier.padding(4.dp))
+            Spacer(Modifier.padding(paddingSmall))
             // Title of current page.
             Text("Settings", style = MaterialTheme.typography.h5)
         }
@@ -160,8 +162,6 @@ class SettingsActivity : ComponentActivity() {
 
         // Surface as a background.
         Surface(color = MaterialTheme.colors.background) {
-            val padding = 16.dp
-
             var themeSubtitle by remember { mutableStateOf(theme) }
             var cacheExpirationString = ""
             when (cacheExpiration) {
@@ -182,7 +182,7 @@ class SettingsActivity : ComponentActivity() {
                         Modifier
                             .fillMaxWidth()
                             .fillMaxHeight()
-                            .padding(vertical = padding)
+                            .padding(vertical = paddingLarge)
                             .verticalScroll(rememberScrollState())
                     ) {
                         PreferenceTitle1(title = "Appearance")
@@ -208,7 +208,7 @@ class SettingsActivity : ComponentActivity() {
                             checked = false, // TODO get this value from shared preferences
                             onToggle = { println(it)/* TODO set shared preferences here */ }
                         )
-                        Divider(modifier = Modifier.padding(bottom = 16.dp))
+                        Divider(modifier = Modifier.padding(bottom = paddingLarge))
 
                         PreferenceTitle1(title = "Preferences")
                         // Cache expiration time selector.
@@ -273,7 +273,7 @@ class SettingsActivity : ComponentActivity() {
                             ).show()
 
                         }
-                        Divider(modifier = Modifier.padding(bottom = 16.dp))
+                        Divider(modifier = Modifier.padding(bottom = paddingLarge))
 
                         PreferenceTitle1(title = "Support")
                         // Email item
@@ -296,7 +296,7 @@ class SettingsActivity : ComponentActivity() {
                         ) {
                             openLink(it)
                         }
-                        Divider(modifier = Modifier.padding(bottom = 16.dp))
+                        Divider(modifier = Modifier.padding(bottom = paddingLarge))
 
                         PreferenceTitle1(title = "About")
                         // Item that links to github source code page.

--- a/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
@@ -1,10 +1,7 @@
 package monster.minions.binocularss.activities.ui.theme
 
-import android.view.RoundedCorner
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 
 val RoundedCorner = Shapes(

--- a/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
@@ -1,11 +1,19 @@
 package monster.minions.binocularss.activities.ui.theme
 
+import android.view.RoundedCorner
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 
-val Shapes = Shapes(
+val RoundedCorner = Shapes(
     small = RoundedCornerShape(4.dp),
-    medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp)
+    medium = RoundedCornerShape(8.dp),
+    large = RoundedCornerShape(16.dp)
 )
+
+val paddingLarge = 16.dp
+val paddingLargeMedium = 12.dp
+val paddingMedium = 8.dp
+val paddingSmall = 4.dp

--- a/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Shape.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.unit.dp
 val RoundedCorner = Shapes(
     small = RoundedCornerShape(4.dp),
     medium = RoundedCornerShape(8.dp),
-    large = RoundedCornerShape(16.dp)
+    large = RoundedCornerShape(16.dp),
 )
 
 val paddingLarge = 16.dp

--- a/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Theme.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Theme.kt
@@ -1,13 +1,10 @@
 package monster.minions.binocularss.activities.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorPalette = darkColors(
     primary = evilMinionPurple,
@@ -54,7 +51,7 @@ fun BinoculaRSSTheme(
     MaterialTheme(
         colors = colors,
         typography = Typography,
-        shapes = Shapes,
+        shapes = RoundedCorner,
         content = content
     )
 }

--- a/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Type.kt
+++ b/app/src/main/java/monster/minions/binocularss/activities/ui/theme/Type.kt
@@ -1,28 +1,5 @@
 package monster.minions.binocularss.activities.ui.theme
 
 import androidx.compose.material.Typography
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
-val Typography = Typography(
-    body1 = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp
-    )
-    /* Other default text styles to override
-    button = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.W500,
-        fontSize = 14.sp
-    ),
-    caption = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp
-    )
-    */
-)
+val Typography = Typography()

--- a/app/src/main/java/monster/minions/binocularss/dataclasses/Article.kt
+++ b/app/src/main/java/monster/minions/binocularss/dataclasses/Article.kt
@@ -2,8 +2,6 @@ package monster.minions.binocularss.dataclasses
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import java.util.Date
-import java.text.SimpleDateFormat
 
 /**
  * A dataclass object representing an Article that is part of an RSS Feed.

--- a/app/src/main/java/monster/minions/binocularss/dataclasses/Feed.kt
+++ b/app/src/main/java/monster/minions/binocularss/dataclasses/Feed.kt
@@ -2,8 +2,9 @@ package monster.minions.binocularss.dataclasses
 
 import android.os.Parcelable
 import androidx.annotation.NonNull
-import androidx.compose.ui.text.toLowerCase
-import androidx.room.*
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
 import kotlinx.parcelize.Parcelize
 import monster.minions.binocularss.room.ArticleListConverter
 import monster.minions.binocularss.room.TagsListConverter

--- a/app/src/main/java/monster/minions/binocularss/operations/FeedTitleComparator.kt
+++ b/app/src/main/java/monster/minions/binocularss/operations/FeedTitleComparator.kt
@@ -1,7 +1,7 @@
 package monster.minions.binocularss.operations
 
 import monster.minions.binocularss.dataclasses.Feed
-import java.util.Comparator
+import java.util.*
 
 class FeedTitleComparator: Comparator<Feed> {
     /**

--- a/app/src/main/java/monster/minions/binocularss/ui/Card.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Card.kt
@@ -23,6 +23,9 @@ import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import monster.minions.binocularss.R
 import monster.minions.binocularss.activities.ArticleActivity
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingLargeMedium
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
 import monster.minions.binocularss.dataclasses.Article
 import java.util.*
 
@@ -38,7 +41,7 @@ fun ArticleCard(context: Context, article: Article, updateValues: (article: Arti
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(8.dp)
+            .padding(paddingMedium)
             .clickable {
                 val intent = Intent(context, ArticleActivity::class.java)
                 intent.putExtra("article", article)
@@ -53,14 +56,14 @@ fun ArticleCard(context: Context, article: Article, updateValues: (article: Arti
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(paddingLarge),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 // Column for title, feed, and time.
                 Column(
                     modifier = Modifier
                         .width(200.dp)
-                        .padding(end = 12.dp)
+                        .padding(end = paddingLargeMedium)
                 ) {
                     article.title?.let { title ->
                         Text(text = title, fontWeight = FontWeight.SemiBold)

--- a/app/src/main/java/monster/minions/binocularss/ui/Card.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Card.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -23,6 +22,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import monster.minions.binocularss.R
 import monster.minions.binocularss.activities.ArticleActivity
+import monster.minions.binocularss.activities.ui.theme.RoundedCorner
 import monster.minions.binocularss.activities.ui.theme.paddingLarge
 import monster.minions.binocularss.activities.ui.theme.paddingLargeMedium
 import monster.minions.binocularss.activities.ui.theme.paddingMedium
@@ -115,13 +115,13 @@ fun CardImage(image: String, description: String = "") {
     // Box for image on the right.
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCorner.medium,
         elevation = 4.dp
     ) {
         Box(
             modifier = Modifier
                 .size(150.dp, 150.dp)
-                .background(MaterialTheme.colors.background, RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colors.background, RoundedCorner.small)
         ) {
             Image(
                 painter = rememberImagePainter(

--- a/app/src/main/java/monster/minions/binocularss/ui/Date.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Date.kt
@@ -6,7 +6,6 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 @SuppressLint("SimpleDateFormat")
-// TODO fix
 fun getTime(pubDate: String, shortOutput: Boolean = false): String {
     var time = pubDate
     val dateFormats = listOf(

--- a/app/src/main/java/monster/minions/binocularss/ui/Date.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Date.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 @SuppressLint("SimpleDateFormat")
 // TODO fix
-fun getTime(pubDate: String): String {
+fun getTime(pubDate: String, shortOutput: Boolean = false): String {
     var time = pubDate
     val dateFormats = listOf(
         "EEE, dd MMM yyyy HH:mm:ss zzz",
@@ -28,19 +28,22 @@ fun getTime(pubDate: String): String {
 
     when {
         diff < 1000L * 60L * 60L -> {
-            time = "${diff / (1000L * 60L)}m"
+            time = "${diff / (1000L * 60L)}" + if (shortOutput) "m" else " months ago"
         }
         diff < 1000L * 60L * 60L * 24L -> {
-            time = "${diff / (1000L * 60L * 60L)}h"
+            time = "${diff / (1000L * 60L * 60L)}" + if (shortOutput) "h" else " hours ago"
         }
         diff < 1000L * 60L * 60L * 24L * 30L -> {
-            time = "${diff / (1000L * 60L * 60L * 24L)}d"
+            val longEnding = if ((diff / (1000L * 60L * 60L * 24L)) == 1L) " day ago" else " days ago"
+            time = "${diff / (1000L * 60L * 60L * 24L)}" + if (shortOutput) "d" else longEnding
         }
         diff < 1000L * 60L * 60L * 24L * 30L * 12L -> {
-            time = "${diff / (1000L * 60L * 60L * 24L * 30L)}M"
+            time =
+                "${diff / (1000L * 60L * 60L * 24L * 30L)}" + if (shortOutput) "M" else " months ago"
         }
         else -> {
-            time = "${diff / (1000L * 60L * 60L * 24L * 30L * 12L)}Y"
+            time =
+                "${diff / (1000L * 60L * 60L * 24L * 30L * 12L)}" + if (shortOutput) "Y" else " years ago"
         }
     }
 

--- a/app/src/main/java/monster/minions/binocularss/ui/Icons.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/Icons.kt
@@ -2,17 +2,16 @@ package monster.minions.binocularss.ui
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PanoramaFishEye
+import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.TaskAlt
-import android.net.Uri
-import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
 import androidx.core.content.ContextCompat.startActivity
-
 import monster.minions.binocularss.dataclasses.Article
 import java.util.*
 import androidx.compose.material.icons.filled.Bookmark as FilledBookmarkIcon

--- a/app/src/main/java/monster/minions/binocularss/ui/NavigationItem.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/NavigationItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.RssFeed
 import androidx.compose.ui.graphics.vector.ImageVector
-import monster.minions.binocularss.R
 
 sealed class NavigationItem(var route: String, var icon: ImageVector, var title: String) {
     object Articles: NavigationItem("articles", Icons.Filled.Article, "Articles")

--- a/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.core.content.ContextCompat.startActivity
+import monster.minions.binocularss.activities.ui.theme.paddingLarge
+import monster.minions.binocularss.activities.ui.theme.paddingMedium
 
 /**
  * Item that runs a callback on click
@@ -46,7 +48,7 @@ fun ActionItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+            .padding(horizontal = paddingLarge, vertical = paddingMedium)
             // Perform action when clicked if not disabled
             .clickable(enabled = !disabled) { onClick() }
     ) {
@@ -84,7 +86,7 @@ fun InformationPopupItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+            .padding(horizontal = paddingLarge, vertical = paddingMedium)
             .clickable { showPopup = true }
     ) {
         // Column that contains title and subtitle if defined.
@@ -118,7 +120,7 @@ fun InformationPopupItem(
                         it.apply(MaterialTheme.colors.background, 4.dp),
                         RoundedCornerShape(cornerSize)
                     )
-                    .padding(16.dp)
+                    .padding(paddingLarge)
             }?.let {
                 Box(
                     it
@@ -156,7 +158,7 @@ fun EmailItem(context: Context, title: String, subtitle: String = "", email: Str
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+            .padding(horizontal = paddingLarge, vertical = paddingMedium)
             .clickable {
                 // on click, send to email application.
                 if (email != "") {
@@ -187,7 +189,7 @@ fun LinkItem(title: String, subtitle: String = "", link: String, openLink: (link
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+            .padding(horizontal = paddingLarge, vertical = paddingMedium)
             // Open link when clicked.
             .clickable { openLink(link) }
     ) {
@@ -225,7 +227,8 @@ fun MultipleOptionItem(
         Modifier
             .fillMaxWidth()
             .clickable { showPopup = true }
-            .padding(start = 16.dp, end = 16.dp, bottom = 8.dp, top = 8.dp)) {
+            .padding(horizontal = paddingLarge, vertical = paddingMedium)
+    ) {
         // Column that renders the title and subtitle.
         Column {
             Text(title)
@@ -257,7 +260,7 @@ fun MultipleOptionItem(
                         it.apply(MaterialTheme.colors.background, 4.dp),
                         RoundedCornerShape(cornerSize)
                     )
-                    .padding(16.dp)
+                    .padding(paddingLarge)
             }?.let {
                 Box(
                     it
@@ -289,7 +292,7 @@ fun MultipleOptionItem(
                                         },
                                         role = Role.RadioButton
                                     )
-                                    .padding(horizontal = 16.dp),
+                                    .padding(horizontal = paddingLarge),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 RadioButton(
@@ -302,7 +305,7 @@ fun MultipleOptionItem(
                                 Text(
                                     text = text,
                                     style = MaterialTheme.typography.body1.merge(),
-                                    modifier = Modifier.padding(start = 16.dp)
+                                    modifier = Modifier.padding(start = paddingLarge)
                                 )
                             }
                         }
@@ -342,7 +345,7 @@ fun ToggleItem(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { checkedState = !checkedState }
-            .padding(start = 16.dp, end = 16.dp, bottom = 8.dp, top = 8.dp),
+            .padding(horizontal = paddingLarge, vertical = paddingMedium),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -377,7 +380,7 @@ fun ToggleItem(
 @Composable
 fun PreferenceTitle(title: String) {
     Text(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        modifier = Modifier.padding(horizontal = paddingLarge, vertical = paddingMedium),
         text = buildAnnotatedString {
             withStyle(style = ParagraphStyle(lineHeight = 30.sp)) {
                 withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {

--- a/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,6 +24,7 @@ import androidx.compose.ui.window.Popup
 import androidx.core.content.ContextCompat.startActivity
 import monster.minions.binocularss.activities.ui.theme.paddingLarge
 import monster.minions.binocularss.activities.ui.theme.paddingMedium
+import monster.minions.binocularss.activities.ui.theme.RoundedCorner
 
 /**
  * Item that runs a callback on click
@@ -102,8 +102,6 @@ fun InformationPopupItem(
     if (showPopup) {
         // Popup size information.
         val popupHeight = 400.dp
-        val cornerSize = 16.dp
-
         Popup(
             alignment = Alignment.Center,
             onDismissRequest = { showPopup = false }
@@ -118,7 +116,7 @@ fun InformationPopupItem(
                     .height(popupHeight)
                     .background(
                         it.apply(MaterialTheme.colors.background, 4.dp),
-                        RoundedCornerShape(cornerSize)
+                        RoundedCorner.large
                     )
                     .padding(paddingLarge)
             }?.let {
@@ -245,7 +243,6 @@ fun MultipleOptionItem(
         for (i in radioOptions) {
             popupHeight += 56.dp
         }
-        val cornerSize = 16.dp
 
         Popup(
             alignment = Alignment.Center,
@@ -258,7 +255,7 @@ fun MultipleOptionItem(
                     .height(popupHeight)
                     .background(
                         it.apply(MaterialTheme.colors.background, 4.dp),
-                        RoundedCornerShape(cornerSize)
+                        RoundedCorner.large
                     )
                     .padding(paddingLarge)
             }?.let {

--- a/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
+++ b/app/src/main/java/monster/minions/binocularss/ui/SettingItems.kt
@@ -13,18 +13,28 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.ParagraphStyle
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.core.content.ContextCompat.startActivity
 import monster.minions.binocularss.activities.ui.theme.paddingLarge
 import monster.minions.binocularss.activities.ui.theme.paddingMedium
-import monster.minions.binocularss.activities.ui.theme.RoundedCorner
+
+/**
+ * Display the title and subtitle of an item.
+ */
+@Composable
+private fun TitleSubtitle(title: String, subtitle: String) {
+    // If there is no subtitle, display only the title.
+    Text(text = title, style = MaterialTheme.typography.subtitle1)
+    if (subtitle != "") {
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.subtitle2,
+            fontWeight = FontWeight.Light
+        )
+    }
+}
 
 /**
  * Item that runs a callback on click
@@ -42,7 +52,7 @@ fun ActionItem(
 ) {
     // Grey out text if disabled
     val alpha by remember {
-        mutableStateOf(if (disabled) 0.6f else 1f)
+        mutableStateOf(if (disabled) 0.6f else 0.8f)
     }
 
     Row(
@@ -50,17 +60,23 @@ fun ActionItem(
             .fillMaxWidth()
             .padding(horizontal = paddingLarge, vertical = paddingMedium)
             // Perform action when clicked if not disabled
-            .clickable(enabled = !disabled) { onClick() }
+            .clickable(enabled = !disabled) {
+                onClick()
+            }
     ) {
         // Column that renders title and subtitle.
         Column {
-            Text(title, color = MaterialTheme.colors.onBackground.copy(alpha))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.onBackground.copy(alpha = alpha),
+            )
             if (subtitle != "") {
                 Text(
                     text = subtitle,
-                    fontWeight = FontWeight.Light,
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colors.onBackground.copy(alpha)
+                    style = MaterialTheme.typography.subtitle2,
+                    color = MaterialTheme.colors.onBackground.copy(alpha = alpha),
+                    fontWeight = FontWeight.Light
                 )
             }
         }
@@ -91,10 +107,7 @@ fun InformationPopupItem(
     ) {
         // Column that contains title and subtitle if defined.
         Column {
-            Text(title)
-            if (subtitle != "") {
-                Text(text = subtitle, fontWeight = FontWeight.Light, fontSize = 12.sp)
-            }
+            TitleSubtitle(title = title, subtitle = subtitle)
         }
     }
 
@@ -116,7 +129,7 @@ fun InformationPopupItem(
                     .height(popupHeight)
                     .background(
                         it.apply(MaterialTheme.colors.background, 4.dp),
-                        RoundedCorner.large
+                        MaterialTheme.shapes.large
                     )
                     .padding(paddingLarge)
             }?.let {
@@ -126,7 +139,11 @@ fun InformationPopupItem(
                     // Render content of popup passed as lambda function along with title and
                     //  close button.
                     Column(modifier = Modifier.selectableGroup()) {
-                        Text(text = title, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.h6,
+                            fontWeight = FontWeight.Bold
+                        )
                         content()
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -170,10 +187,7 @@ fun EmailItem(context: Context, title: String, subtitle: String = "", email: Str
             }) {
         // Render title and subtitle.
         Column {
-            Text(title)
-            if (subtitle != "") {
-                Text(text = subtitle, fontWeight = FontWeight.Light, fontSize = 12.sp)
-            }
+            TitleSubtitle(title = title, subtitle = subtitle)
         }
     }
 }
@@ -193,10 +207,7 @@ fun LinkItem(title: String, subtitle: String = "", link: String, openLink: (link
     ) {
         // Column that renders title and subtitle.
         Column {
-            Text(title)
-            if (subtitle != "") {
-                Text(text = subtitle, fontWeight = FontWeight.Light, fontSize = 12.sp)
-            }
+            TitleSubtitle(title = title, subtitle = subtitle)
         }
     }
 }
@@ -229,10 +240,7 @@ fun MultipleOptionItem(
     ) {
         // Column that renders the title and subtitle.
         Column {
-            Text(title)
-            if (subtitle != "") {
-                Text(text = subtitle, fontWeight = FontWeight.Light, fontSize = 12.sp)
-            }
+            TitleSubtitle(title = title, subtitle = subtitle)
         }
     }
 
@@ -255,7 +263,7 @@ fun MultipleOptionItem(
                     .height(popupHeight)
                     .background(
                         it.apply(MaterialTheme.colors.background, 4.dp),
-                        RoundedCorner.large
+                        MaterialTheme.shapes.large
                     )
                     .padding(paddingLarge)
             }?.let {
@@ -270,7 +278,11 @@ fun MultipleOptionItem(
 
                     // Render radio buttons, title, text, and cancel button.
                     Column(modifier = Modifier.selectableGroup()) {
-                        Text(text = subtitle, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.h6,
+                            fontWeight = FontWeight.Bold
+                        )
                         radioOptions.forEach { text ->
                             Row(
                                 modifier = Modifier
@@ -348,10 +360,7 @@ fun ToggleItem(
     ) {
         // Render title and subtitle.
         Column {
-            Text(title)
-            if (subtitle != "") {
-                Text(subtitle)
-            }
+            TitleSubtitle(title = title, subtitle = subtitle)
         }
         // Switch that toggles preferences.
         Switch(
@@ -378,13 +387,9 @@ fun ToggleItem(
 fun PreferenceTitle(title: String) {
     Text(
         modifier = Modifier.padding(horizontal = paddingLarge, vertical = paddingMedium),
-        text = buildAnnotatedString {
-            withStyle(style = ParagraphStyle(lineHeight = 30.sp)) {
-                withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {
-                    append(title)
-                }
-            }
-        },
-        fontSize = 20.sp
+        text = title,
+        style = MaterialTheme.typography.h6,
+        color = MaterialTheme.colors.primary,
+        fontWeight = FontWeight.Normal,
     )
 }


### PR DESCRIPTION
This branch ensures that all padding values are using standardized values found in `activities/ui.theme/Shape.kt`, all rounded corner shapes are using standardized values found in the same file, and all text objects are using standardized values found in `activities/ui.theme/Type.kt`.

As a bonus, I also extracted a composable that was being reused in `SettingItems.kt` so there is less code duplication.